### PR TITLE
fix: restrict top-level workflow token permissions to read-only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,17 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
-  security-events: write
-  packages: write
-  actions: read
 
 jobs:
   gitctl:
     name: gitctl
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      security-events: write
+      packages: write
+      actions: read
     uses: ./.github/workflows/reusable-go-ci.yaml
     with:
       name: gitctl

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '44 16 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,15 +3,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  packages: write # to be able to publish packages
-  contents: write # to be able to publish a GitHub release
-  issues: write # to be able to comment on released issues
-  pull-requests: write # to be able to comment on released pull requests
-  id-token: write # to enable use of OIDC for npm provenance
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write # to be able to publish packages
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: 'Generate token'
         id: generate_token

--- a/.github/workflows/reusable-go-ci.yaml
+++ b/.github/workflows/reusable-go-ci.yaml
@@ -87,6 +87,9 @@ on:
         description: "Image digest from the build image step"
         value: ${{ jobs.build.outputs.image_digest }}
 
+permissions:
+  contents: read
+
 jobs:
   static_checks:
     name: "Static Checks for ${{ inputs.name }}"
@@ -135,6 +138,10 @@ jobs:
     name: "Tests & Coverage for ${{ inputs.name }}"
     if: ${{ inputs.run_tests }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     outputs:
       test_reports_artifact_id: ${{ steps.upload_test_reports_artifact_step.outputs.artifact-id }}
     steps:
@@ -253,6 +260,10 @@ jobs:
     name: "CodeQL Analysis for ${{ inputs.name }}"
     if: ${{ inputs.run_code_analysis }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -306,6 +317,9 @@ jobs:
     if: ${{ inputs.run_build_image && (needs.static_checks.result != 'failure') && (needs.tests.result != 'failure') }}
     needs: [tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_digest: ${{ steps.build_image_ko_step.outputs.digest }}
       repo_lower: ${{ steps.repo_lower.outputs.repo }}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
   - Move write permissions from top-level to job-level in `ci.yaml`, `release.yaml`, `reusable-go-ci.yaml`, and `codeql.yml`                                                                                                                                                                                       
   - Ensures the GITHUB_TOKEN follows least-privilege by only granting write access where jobs actually need it
   - Resolves OpenSSF Scorecard Token-Permissions alerts (#9, #18-23)                                                                                                                                                                                                                                               

   ## Details

   | Workflow | Change |
   |----------|--------|
   | `ci.yaml` | Top-level restricted to `contents: read`; write perms moved to `gitctl` job |
   | `release.yaml` | Top-level restricted to `contents: read`; write perms moved to `release` job |
   | `reusable-go-ci.yaml` | Added top-level `contents: read`; added job-level perms for `tests`, `codeql`, and `build` jobs |
   | `codeql.yml` | Added top-level `contents: read` (job already had proper permissions) |

   **Note:** Alert #1 (`go.yml`) references a file that no longer exists and should auto-dismiss or be manually closed.

   ## Test plan

   - [ ] CI workflow passes on this PR (validates permissions are sufficient)
   - [ ] Verify Scorecard re-scan resolves Token-Permissions alerts